### PR TITLE
Schema registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You could simply ingest all messages from a Kafka topic and check if they correl
 
 ### Configuration
 
-In order to communicate with the Zeebe workflow engine, the connector has to create a Zeebe client. 
+In order to communicate with the Zeebe workflow engine, the connector has to create a Zeebe client.
 
 #### Camunda Cloud Properties
 
@@ -127,6 +127,13 @@ If this custom header is not present, then all variables in the scope will be se
 ## Configuring Error Handling of Kafka Connect, e.g. Logging or Dead Letter Queues
 
 Kafka Connect allows you to configure what happens if a message cannot be processed. A great explanation can be found in [Kafka Connect Deep Dive – Error Handling and Dead Letter Queues](https://www.confluent.io/blog/kafka-connect-deep-dive-error-handling-dead-letter-queues). This of course also applies to this connector.
+
+# Development
+
+To ease with development, you can add this environment variable to kafka-connect:
+`"JAVA_TOOL_OPTIONS": "-agentlib:jdwp=transport=dt_socket,address=*:5005,server=y,suspend=n"`
+
+And then use [remote debugging](https://www.jetbrains.com/help/idea/tutorial-remote-debug.html)
 
 # Confluent Hub
 

--- a/docker/docker-compose-with-zeebe.yml
+++ b/docker/docker-compose-with-zeebe.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   zeebe:
-    image: camunda/zeebe:0.21.1
+    image: camunda/zeebe:0.26.0
     hostname: zeebe
     ports:
       - "26500:26500"
@@ -20,7 +20,7 @@ services:
       - ./operate.yml:/usr/local/operate/config/application.yml
     depends_on:
       - elasticsearch
-      
+
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.3
     ports:
@@ -41,7 +41,7 @@ services:
       ZOO_SERVERS: server.1=zookeeper:2888:3888
 
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.3.0
+    image: confluentinc/cp-enterprise-kafka:5.5.3
     hostname: kafka
     ports:
       - "9092:9092"
@@ -60,7 +60,7 @@ services:
       - zookeeper
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.0
+    image: confluentinc/cp-schema-registry:5.5.3
     hostname: schema-registry
     ports:
       - "8081:8081"
@@ -73,7 +73,7 @@ services:
       - kafka
 
   connect:
-    image: confluentinc/cp-kafka-connect:5.3.0
+    image: confluentinc/cp-kafka-connect:5.5.3
     hostname: connect
     ports:
       - "8083:8083"
@@ -105,7 +105,7 @@ services:
       - zeebe
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.3.0
+    image: confluentinc/cp-enterprise-control-center:5.5.3
     hostname: control-center
     ports:
       - "9021:9021"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       ZOO_SERVERS: server.1=zookeeper:2888:3888
 
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.3.0
+    image: confluentinc/cp-enterprise-kafka:5.5.3
     hostname: kafka
     ports:
       - "9092:9092"
@@ -41,7 +41,7 @@ services:
       - zookeeper
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.0
+    image: confluentinc/cp-schema-registry:5.5.3
     hostname: schema-registry
     ports:
       - "8081:8081"
@@ -54,7 +54,7 @@ services:
       - kafka
 
   connect:
-    image: confluentinc/cp-kafka-connect:5.3.0
+    image: confluentinc/cp-kafka-connect:5.5.3
     hostname: connect
     ports:
       - "8083:8083"
@@ -85,7 +85,7 @@ services:
       - kafka
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.3.0
+    image: confluentinc/cp-enterprise-control-center:5.5.3
     hostname: control-center
     ports:
       - "9021:9021"

--- a/src/main/java/io/zeebe/kafka/connect/sink/message/Message.java
+++ b/src/main/java/io/zeebe/kafka/connect/sink/message/Message.java
@@ -69,6 +69,17 @@ public final class Message {
     return timeToLive != null;
   }
 
+  @Override
+  public String toString() {
+    return "Message{"
+      + "id='" + id  + '\''
+      + ", name='" + name  + '\''
+      + ", key='" + key + '\''
+      + ", variables=" + variables
+      + ", timeToLive=" + timeToLive
+      + '}';
+  }
+
   public static final class Builder {
     private String id;
     private String name;


### PR DESCRIPTION
Add the ability to use the schema-registry when using the Sink Connector

Use the following config on the connector to enable it : 
```json
    "value.converter": "io.confluent.connect.json.JsonSchemaConverter",
    "value.converter.schema.registry.url": "http://connect:8081"
```