### PR TITLE
Add config for self-managed Zeebe cluster

### DIFF
--- a/src/main/java/io/zeebe/kafka/connect/util/ZeebeClientConfigDef.java
+++ b/src/main/java/io/zeebe/kafka/connect/util/ZeebeClientConfigDef.java
@@ -30,8 +30,12 @@ public final class ZeebeClientConfigDef {
 
   public static final String CAMUNDA_CLOUD_CLUSTER_ID_CONFIG = "zeebe.client.cloud.clusterId";
   public static final String CAMUNDA_CLOUD_REGION_CONFIG = "zeebe.client.cloud.region";
-  public static final String CAMUNDA_CLOUD_CLIENT_ID_CONFIG = "zeebe.client.cloud.clientId";
-  public static final String CAMUNDA_CLOUD_CLIENT_SECRET_CONFIG = "zeebe.client.cloud.clientSecret";
+  public static final String CLIENT_ID_CONFIG = "zeebe.client.clientId";
+  public static final String CLIENT_SECRET_CONFIG = "zeebe.client.clientSecret";
+  public static final String ZEEBE_TOKEN_AUDIENCE_CONFIG = "zeebe.client.token.audience";
+  public static final String ZEEBE_AUTHORIZATION_SERVER_URL_CONFIG =
+      "zeebe.client.authorization.server.url";
+  public static final String ZEEBE_CLIENT_CONFIG_PATH_CONFIG = "zeebe.client.config.path";
 
   private static final String CLIENT_CONFIG_GROUP = "Zeebe Client";
   private static final String GATEWAY_ADDRESS_DEFAULT = "localhost:26500";
@@ -48,8 +52,16 @@ public final class ZeebeClientConfigDef {
       "Camunda Cloud Cluster ID to connect to (on cloud.camunda.io). If set this is used instead of the gateway address.";
   private static final String CAMUNDA_CLOUD_REGION_DOC =
       "Camunda Cloud Region the cluster is provisioned in";
-  private static final String CAMUNDA_CLOUD_CLIENT_ID_DOC = "Camunda Cloud Client ID";
-  private static final String CAMUNDA_CLOUD_CLIENT_SECRET_DOC = "Camunda Cloud Client Secret";
+  private static final String CLIENT_ID_DOC =
+      "The client ID used to request an access token from Camunda Cloud or the authorization server";
+  private static final String CLIENT_SECRET_DOC =
+      "The client secret used to request an access token from Camunda Cloud or the authorization server";
+  private static final String ZEEBE_TOKEN_AUDIENCE_DOC =
+      "The address for which the authorization server token should be valid";
+  private static final String ZEEBE_AUTHORIZATION_SERVER_URL_DOC =
+      "The URL of the authorization server from which the access token will be requested (by default, configured for Camunda Cloud)";
+  private static final String ZEEBE_CLIENT_CONFIG_PATH_DOC =
+      "The path to a cache file where the access tokens will be stored (by default, it's $HOME/.camunda/credentials)";
 
   private ZeebeClientConfigDef() {}
 
@@ -108,24 +120,54 @@ public final class ZeebeClientConfigDef {
             Width.MEDIUM,
             "Zeebe Cluster Region")
         .define(
-            CAMUNDA_CLOUD_CLIENT_ID_CONFIG,
+            CLIENT_ID_CONFIG,
             Type.STRING,
             null,
             Importance.LOW,
-            CAMUNDA_CLOUD_CLIENT_ID_DOC,
+            CLIENT_ID_DOC,
             CLIENT_CONFIG_GROUP,
             ++order,
             Width.MEDIUM,
             "Zeebe Client Id")
         .define(
-            CAMUNDA_CLOUD_CLIENT_SECRET_CONFIG,
+            CLIENT_SECRET_CONFIG,
             Type.STRING,
             null,
             Importance.LOW,
-            CAMUNDA_CLOUD_CLIENT_SECRET_DOC,
+            CLIENT_SECRET_DOC,
             CLIENT_CONFIG_GROUP,
             ++order,
             Width.MEDIUM,
-            "Zeebe Client Secret");
+            "Zeebe Client Secret")
+        .define(
+            ZEEBE_TOKEN_AUDIENCE_CONFIG,
+            Type.STRING,
+            null,
+            Importance.LOW,
+            ZEEBE_TOKEN_AUDIENCE_DOC,
+            CLIENT_CONFIG_GROUP,
+            ++order,
+            Width.MEDIUM,
+            "Zeebe Token Audience")
+        .define(
+            ZEEBE_AUTHORIZATION_SERVER_URL_CONFIG,
+            Type.STRING,
+            null,
+            Importance.LOW,
+            ZEEBE_AUTHORIZATION_SERVER_URL_DOC,
+            CLIENT_CONFIG_GROUP,
+            ++order,
+            Width.MEDIUM,
+            "Zeebe Authorization Server URL")
+        .define(
+            ZEEBE_CLIENT_CONFIG_PATH_CONFIG,
+            Type.STRING,
+            null,
+            Importance.LOW,
+            ZEEBE_CLIENT_CONFIG_PATH_DOC,
+            CLIENT_CONFIG_GROUP,
+            ++order,
+            Width.MEDIUM,
+            "Zeebe Client Config Path");
   }
 }


### PR DESCRIPTION
Fixes #77.

Currently, the only way to connect to a self-managed Zeebe cluster with a client ID and secret is to set [these environment variables](https://docs.camunda.io/docs/self-managed/zeebe-deployment/security/client-authorization/#:~:text=ZEEBE_CLIENT_ID%20%2D%20The%20client,HOME/.camunda/credentials).

I think the connector should provide the option to set these in the connector properties.